### PR TITLE
Fix Google Fonts link on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MOMO 2025: The Audiobook Prophecy</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Orbitron', sans-serif;
+      background: linear-gradient(to bottom, #000000, #111111);
+      color: #f5f5f5;
+      overflow-x: hidden;
+    }
+    header {
+      padding: 40px;
+      text-align: center;
+      background: #ff007f;
+      color: #fff;
+      font-size: 2.5em;
+      text-shadow: 0 0 10px #ff99cc;
+    }
+    .subtitle {
+      text-align: center;
+      color: #ffcccc;
+      margin-bottom: 40px;
+      font-style: italic;
+    }
+    .tracklist {
+      max-width: 800px;
+      margin: auto;
+      padding: 20px;
+    }
+    .track {
+      margin-bottom: 30px;
+      background-color: #1a1a1a;
+      padding: 20px;
+      border-left: 5px solid #ff007f;
+      box-shadow: 0 0 10px #ff007f33;
+    }
+    .track h2 {
+      margin: 0 0 10px;
+      font-size: 1.4em;
+      color: #ff99cc;
+    }
+    .track p {
+      margin: 0 0 10px;
+      color: #bbb;
+      font-size: 0.95em;
+    }
+    audio {
+      width: 100%;
+    }
+    footer {
+      text-align: center;
+      padding: 40px 10px;
+      color: #666;
+      font-size: 0.9em;
+    }
+    .bg-audio {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      opacity: 0.03;
+    }
+  </style>
+</head>
+<body>
+  <header>MOMO 2025 · The Audiobook Prophecy</header>
+  <div class="subtitle">This was never a campaign. It was a transmission.</div>
+
+  <div class="tracklist">
+    <!-- Audio tracks go here -->
+  </div>
+
+  <footer>Broadcasted with love by SYC &mdash; MOMO 2025</footer>
+
+  <audio class="bg-audio" autoplay loop>
+    <source src="bg/ambient_static.mp3" type="audio/mpeg">
+  </audio>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add extracted `index.html` landing page
- fix broken Google Fonts link in the landing page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b6a7c6808832a89d089063d585068