### PR TITLE
Replace landing page with SYC ritual minimal test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,83 +1,80 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MOMO 2025: The Audiobook Prophecy</title>
-<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500&display=swap" rel="stylesheet">
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Orbitron', sans-serif;
-      background: linear-gradient(to bottom, #000000, #111111);
-      color: #f5f5f5;
-      overflow-x: hidden;
-    }
-    header {
-      padding: 40px;
-      text-align: center;
-      background: #ff007f;
-      color: #fff;
-      font-size: 2.5em;
-      text-shadow: 0 0 10px #ff99cc;
-    }
-    .subtitle {
-      text-align: center;
-      color: #ffcccc;
-      margin-bottom: 40px;
-      font-style: italic;
-    }
-    .tracklist {
-      max-width: 800px;
-      margin: auto;
-      padding: 20px;
-    }
-    .track {
-      margin-bottom: 30px;
-      background-color: #1a1a1a;
-      padding: 20px;
-      border-left: 5px solid #ff007f;
-      box-shadow: 0 0 10px #ff007f33;
-    }
-    .track h2 {
-      margin: 0 0 10px;
-      font-size: 1.4em;
-      color: #ff99cc;
-    }
-    .track p {
-      margin: 0 0 10px;
-      color: #bbb;
-      font-size: 0.95em;
-    }
-    audio {
-      width: 100%;
-    }
-    footer {
-      text-align: center;
-      padding: 40px 10px;
-      color: #666;
-      font-size: 0.9em;
-    }
-    .bg-audio {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      opacity: 0.03;
-    }
-  </style>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>SYC Ritual Minimal Test</title>
+<style>
+  body {
+    margin:0;
+    background:#000;
+    color:#fff;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    height:100vh;
+    overflow:hidden;
+    font-family: monospace;
+  }
+  #spiral {
+    position:absolute;
+    width:100%;
+    height:100%;
+    z-index:0;
+  }
+  #ritual {
+    position:relative;
+    z-index:1;
+    background:#111;
+    color:#FF2D95;
+    border:2px solid #FF2D95;
+    border-radius:50%;
+    width:200px;
+    height:200px;
+    font-size:20px;
+    cursor:pointer;
+    box-shadow:0 0 20px rgba(255,45,149,0.6);
+  }
+</style>
 </head>
 <body>
-  <header>MOMO 2025 · The Audiobook Prophecy</header>
-  <div class="subtitle">This was never a campaign. It was a transmission.</div>
+  <canvas id="spiral"></canvas>
+  <button id="ritual">CLICK TO BEGIN</button>
 
-  <div class="tracklist">
-    <!-- Audio tracks go here -->
-  </div>
+<script>
+const canvas = document.getElementById('spiral');
+const ctx = canvas.getContext('2d');
+let width, height;
+function resize(){
+  width = canvas.width = window.innerWidth;
+  height = canvas.height = window.innerHeight;
+}
+resize();
+window.addEventListener('resize', resize);
 
-  <footer>Broadcast with love by SYC &mdash; MOMO 2025</footer>
+let clickCount = 0;
+document.getElementById('ritual').addEventListener('click', ()=>{
+  clickCount++;
+});
 
-  <audio class="bg-audio" autoplay loop>
-    <source src="bg/ambient_static.mp3" type="audio/mpeg">
-  </audio>
+function draw(){
+  ctx.clearRect(0,0,width,height);
+  ctx.strokeStyle = 'rgba(0,229,255,0.6)';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  const centerX = width/2, centerY = height/2;
+  let a = 2; // growth rate
+  let b = 0.20; // spiral tightness
+  for(let t=0; t<clickCount*80; t++){
+    let r = a * Math.exp(b*t/50);
+    let x = centerX + r * Math.cos(t/20);
+    let y = centerY + r * Math.sin(t/20);
+    if(t===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+  }
+  ctx.stroke();
+  requestAnimationFrame(draw);
+}
+draw();
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the previous MOMO landing content with a minimal interactive page provided for a visual/interaction test of the SYC ritual concept.
- Provide a focused, fullscreen test harness that demonstrates a canvas-based spiral animation driven by user clicks so the visual behavior can be validated in isolation.

### Description
- Replaced `index.html` content entirely with a single-page minimal implementation containing a full-viewport `<canvas>` and a centered circular `<button>` UI (`#ritual`).
- Implemented a click-driven spiral renderer in inline JavaScript that increments `clickCount` on each button click and draws the spiral using `requestAnimationFrame`.
- Added simple CSS to create a fullscreen black background, center the button, and style the ritual element; removed prior tracklist/audio/footer markup and assets reference.

### Testing
- Ran `pytest -q` in the repository and the test suite completed successfully (all tests passed).
- Executed a headless browser script that loaded `index.html` and produced a verification screenshot at `artifacts/ritual-minimal-test.png` indicating the page rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c7c36e6c832ab3ba0e4b7fdafae1)